### PR TITLE
chore: setup clippy

### DIFF
--- a/atcoder/abc257/c/main.rs
+++ b/atcoder/abc257/c/main.rs
@@ -79,7 +79,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc257/d/main.rs
+++ b/atcoder/abc257/d/main.rs
@@ -125,7 +125,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc257/d/main.rs
+++ b/atcoder/abc257/d/main.rs
@@ -13,6 +13,7 @@ struct F64ord(f64);
 
 impl Eq for F64ord {}
 
+#[allow(clippy::derive_ord_xor_partial_ord)]
 impl Ord for F64ord {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.partial_cmp(other).unwrap()
@@ -46,7 +47,7 @@ fn main_case() -> io::Result<()> {
         let mut heap: BTreeSet<(F64ord, usize)> = BTreeSet::new(); // (distance, vertex)
         heap.insert((F64ord(0.0), start));
 
-        while heap.len() > 0 {
+        while !heap.is_empty() {
             let &(d, i) = heap.iter().next().unwrap();
             result[i] = d.0;
             heap.remove(&(d, i));

--- a/atcoder/abc257/e/main.rs
+++ b/atcoder/abc257/e/main.rs
@@ -74,7 +74,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc258/d/main.rs
+++ b/atcoder/abc258/d/main.rs
@@ -80,7 +80,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc258/e/main.rs
+++ b/atcoder/abc258/e/main.rs
@@ -135,7 +135,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc259/b/main.rs
+++ b/atcoder/abc259/b/main.rs
@@ -70,7 +70,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc259/c/main.rs
+++ b/atcoder/abc259/c/main.rs
@@ -78,7 +78,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc259/d/main.rs
+++ b/atcoder/abc259/d/main.rs
@@ -144,7 +144,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc259/e/main.rs
+++ b/atcoder/abc259/e/main.rs
@@ -92,7 +92,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc260/a/main.rs
+++ b/atcoder/abc260/a/main.rs
@@ -56,7 +56,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc260/b/main-1.51.rs
+++ b/atcoder/abc260/b/main-1.51.rs
@@ -120,7 +120,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc260/b/main.rs
+++ b/atcoder/abc260/b/main.rs
@@ -121,7 +121,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc260/d/main.rs
+++ b/atcoder/abc260/d/main.rs
@@ -104,7 +104,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc260/e/main.rs
+++ b/atcoder/abc260/e/main.rs
@@ -134,7 +134,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc260/f/main.rs
+++ b/atcoder/abc260/f/main.rs
@@ -122,7 +122,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc260/f/main_v2.rs
+++ b/atcoder/abc260/f/main_v2.rs
@@ -99,7 +99,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc261/a/main.rs
+++ b/atcoder/abc261/a/main.rs
@@ -50,7 +50,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc261/b/main.rs
+++ b/atcoder/abc261/b/main.rs
@@ -59,7 +59,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc261/c/main.rs
+++ b/atcoder/abc261/c/main.rs
@@ -79,7 +79,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc261/d/main.rs
+++ b/atcoder/abc261/d/main.rs
@@ -68,7 +68,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc261/e/main.rs
+++ b/atcoder/abc261/e/main.rs
@@ -107,7 +107,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc261/f/main.rs
+++ b/atcoder/abc261/f/main.rs
@@ -142,7 +142,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc262/a/main.rs
+++ b/atcoder/abc262/a/main.rs
@@ -47,7 +47,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc262/b/main.rs
+++ b/atcoder/abc262/b/main.rs
@@ -81,7 +81,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc262/c/main.rs
+++ b/atcoder/abc262/c/main.rs
@@ -66,7 +66,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc262/d/main.rs
+++ b/atcoder/abc262/d/main.rs
@@ -75,7 +75,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc262/d/main_v2.rs
+++ b/atcoder/abc262/d/main_v2.rs
@@ -122,7 +122,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc262/e/main.rs
+++ b/atcoder/abc262/e/main.rs
@@ -183,7 +183,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc263/a/main.rs
+++ b/atcoder/abc263/a/main.rs
@@ -51,7 +51,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc263/a/main_v2.rs
+++ b/atcoder/abc263/a/main_v2.rs
@@ -48,7 +48,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc263/b/main.rs
+++ b/atcoder/abc263/b/main.rs
@@ -54,7 +54,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc263/c/main.rs
+++ b/atcoder/abc263/c/main.rs
@@ -16,7 +16,7 @@ fn main_case() -> io::Result<()> {
     Ok(())
 }
 
-fn solve<F: Fn(&Vec<usize>) -> ()>(s: usize, k: usize, i: usize, result: &mut Vec<usize>, f: &F) {
+fn solve<F: Fn(&Vec<usize>)>(s: usize, k: usize, i: usize, result: &mut Vec<usize>, f: &F) {
     if (s.count_ones() as usize) < k {
         return;
     }

--- a/atcoder/abc263/c/main.rs
+++ b/atcoder/abc263/c/main.rs
@@ -88,7 +88,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc263/d/main.rs
+++ b/atcoder/abc263/d/main.rs
@@ -71,7 +71,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc263/d/main_v2.rs
+++ b/atcoder/abc263/d/main_v2.rs
@@ -61,7 +61,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc263/e/main.rs
+++ b/atcoder/abc263/e/main.rs
@@ -169,7 +169,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc264/a/main.rs
+++ b/atcoder/abc264/a/main.rs
@@ -46,7 +46,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc264/b/main.rs
+++ b/atcoder/abc264/b/main.rs
@@ -45,7 +45,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc264/c/main.rs
+++ b/atcoder/abc264/c/main.rs
@@ -156,7 +156,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc264/c/main_v2.rs
+++ b/atcoder/abc264/c/main_v2.rs
@@ -120,7 +120,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc264/d/main.rs
+++ b/atcoder/abc264/d/main.rs
@@ -63,7 +63,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc264/e/main.rs
+++ b/atcoder/abc264/e/main.rs
@@ -163,7 +163,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc265/c/main.rs
+++ b/atcoder/abc265/c/main.rs
@@ -112,7 +112,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc265/d/main.rs
+++ b/atcoder/abc265/d/main.rs
@@ -91,7 +91,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc266/c/main.rs
+++ b/atcoder/abc266/c/main.rs
@@ -66,7 +66,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc266/d/main.rs
+++ b/atcoder/abc266/d/main.rs
@@ -87,7 +87,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc266/e/main.rs
+++ b/atcoder/abc266/e/main.rs
@@ -59,7 +59,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc266/f/main.rs
+++ b/atcoder/abc266/f/main.rs
@@ -195,7 +195,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc267/c/main.rs
+++ b/atcoder/abc267/c/main.rs
@@ -61,7 +61,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc267/d/main.rs
+++ b/atcoder/abc267/d/main.rs
@@ -70,7 +70,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc268/c/main.rs
+++ b/atcoder/abc268/c/main.rs
@@ -63,7 +63,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc268/d/main.rs
+++ b/atcoder/abc268/d/main.rs
@@ -172,7 +172,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc269/c/main.rs
+++ b/atcoder/abc269/c/main.rs
@@ -72,7 +72,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc269/d/main.rs
+++ b/atcoder/abc269/d/main.rs
@@ -116,7 +116,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc269/e/main.rs
+++ b/atcoder/abc269/e/main.rs
@@ -18,7 +18,7 @@ fn main_case() -> io::Result<()> {
         read_tokens::<usize>().map(|v| v[0])
     };
 
-    let answer = |i: usize| -> () {
+    let answer = |i: usize| {
         println!("! {} {}", i + 1, 1);
     };
 

--- a/atcoder/abc269/e/main.rs
+++ b/atcoder/abc269/e/main.rs
@@ -58,7 +58,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc269/e/main_v2.rs
+++ b/atcoder/abc269/e/main_v2.rs
@@ -83,7 +83,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc270/c/main.rs
+++ b/atcoder/abc270/c/main.rs
@@ -92,7 +92,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc270/d/main.rs
+++ b/atcoder/abc270/d/main.rs
@@ -65,7 +65,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc270/e/main.rs
+++ b/atcoder/abc270/e/main.rs
@@ -93,7 +93,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc271/c/main.rs
+++ b/atcoder/abc271/c/main.rs
@@ -78,7 +78,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc271/c/main_v2.rs
+++ b/atcoder/abc271/c/main_v2.rs
@@ -96,7 +96,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc271/d/main.rs
+++ b/atcoder/abc271/d/main.rs
@@ -48,7 +48,7 @@ fn main_case() -> io::Result<()> {
         for head in heads {
             print!("{}", if head { 'H' } else { 'T' });
         }
-        println!("");
+        println!();
     }
 
     Ok(())

--- a/atcoder/abc271/d/main.rs
+++ b/atcoder/abc271/d/main.rs
@@ -95,7 +95,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc271/e/main.rs
+++ b/atcoder/abc271/e/main.rs
@@ -80,7 +80,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc272/c/main.rs
+++ b/atcoder/abc272/c/main.rs
@@ -58,7 +58,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc272/d/main.rs
+++ b/atcoder/abc272/d/main.rs
@@ -41,7 +41,7 @@ fn main_case() -> io::Result<()> {
             }
             print!("{}", dists[i][j]);
         }
-        println!("");
+        println!();
     }
     Ok(())
 }

--- a/atcoder/abc272/d/main.rs
+++ b/atcoder/abc272/d/main.rs
@@ -113,7 +113,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc273/d/main.rs
+++ b/atcoder/abc273/d/main.rs
@@ -164,7 +164,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc273/e/main.rs
+++ b/atcoder/abc273/e/main.rs
@@ -120,7 +120,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc273/e/main.rs
+++ b/atcoder/abc273/e/main.rs
@@ -45,7 +45,7 @@ fn main_case() -> io::Result<()> {
         print!("{}", result);
         history.push(next);
     }
-    println!("");
+    println!();
 
     Ok(())
 }

--- a/atcoder/abc274/c/main.rs
+++ b/atcoder/abc274/c/main.rs
@@ -67,7 +67,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc274/d/main.rs
+++ b/atcoder/abc274/d/main.rs
@@ -96,7 +96,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc274/e/main.rs
+++ b/atcoder/abc274/e/main.rs
@@ -129,7 +129,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc275/c/main.rs
+++ b/atcoder/abc275/c/main.rs
@@ -114,7 +114,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc275/d/main.rs
+++ b/atcoder/abc275/d/main.rs
@@ -69,7 +69,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc275/e/main.rs
+++ b/atcoder/abc275/e/main.rs
@@ -75,7 +75,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc276/d/main.rs
+++ b/atcoder/abc276/d/main.rs
@@ -84,7 +84,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc276/e/main.rs
+++ b/atcoder/abc276/e/main.rs
@@ -145,7 +145,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc276/f/main.rs
+++ b/atcoder/abc276/f/main.rs
@@ -225,7 +225,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc277/c/main.rs
+++ b/atcoder/abc277/c/main.rs
@@ -94,7 +94,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc277/d/main.rs
+++ b/atcoder/abc277/d/main.rs
@@ -90,7 +90,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc277/d/main_v2.rs
+++ b/atcoder/abc277/d/main_v2.rs
@@ -110,7 +110,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc277/e/main.rs
+++ b/atcoder/abc277/e/main.rs
@@ -121,7 +121,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc278/d/main.rs
+++ b/atcoder/abc278/d/main.rs
@@ -128,7 +128,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc278/e/main.rs
+++ b/atcoder/abc278/e/main.rs
@@ -43,7 +43,7 @@ fn main_case() -> io::Result<()> {
             }
             print!(" {}", current.len());
         }
-        println!("");
+        println!();
 
         current = counts.clone();
     }

--- a/atcoder/abc278/e/main.rs
+++ b/atcoder/abc278/e/main.rs
@@ -114,7 +114,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc278/f/main.rs
+++ b/atcoder/abc278/f/main.rs
@@ -176,7 +176,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc279/d/main.rs
+++ b/atcoder/abc279/d/main.rs
@@ -7,7 +7,6 @@ use std::{fmt::Debug, io, str::FromStr};
 fn main_case() -> io::Result<()> {
     // ~ 10^18
     let (a, b) = read_tokens::<usize>().map(|v| (v[0], v[1]))?;
-    a as f64;
 
     // f(x) = a (x + 1)^(-1/2) + b x
     let f = |x: usize| -> f64 {

--- a/atcoder/abc279/d/main.rs
+++ b/atcoder/abc279/d/main.rs
@@ -83,7 +83,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc279/e/main.rs
+++ b/atcoder/abc279/e/main.rs
@@ -96,7 +96,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc279/e/main_v2.rs
+++ b/atcoder/abc279/e/main_v2.rs
@@ -118,7 +118,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc279/f/main.rs
+++ b/atcoder/abc279/f/main.rs
@@ -127,7 +127,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc280/d/brute.rs
+++ b/atcoder/abc280/d/brute.rs
@@ -62,7 +62,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc280/d/main.rs
+++ b/atcoder/abc280/d/main.rs
@@ -117,7 +117,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc280/d/main_v1.rs
+++ b/atcoder/abc280/d/main_v1.rs
@@ -116,7 +116,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc280/d/main_v1.rs
+++ b/atcoder/abc280/d/main_v1.rs
@@ -10,7 +10,7 @@ fn main_case() -> io::Result<()> {
 
     // factorize
     let factors = factorize(k);
-    assert!(factors.len() > 0);
+    assert!(!factors.is_empty());
     // dbg!(&factors);
 
     // solve for each factor and take maximum

--- a/atcoder/abc280/e/main.rs
+++ b/atcoder/abc280/e/main.rs
@@ -150,7 +150,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc280/f/main.rs
+++ b/atcoder/abc280/f/main.rs
@@ -187,7 +187,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc281/d/main.rs
+++ b/atcoder/abc281/d/main.rs
@@ -69,7 +69,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc281/e/main.rs
+++ b/atcoder/abc281/e/main.rs
@@ -162,7 +162,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc281/e/main.rs
+++ b/atcoder/abc281/e/main.rs
@@ -44,7 +44,7 @@ fn main_case() -> io::Result<()> {
             tree2.set(order_inv[i + m], ls[i + m]);
         }
     }
-    println!("");
+    println!();
 
     Ok(())
 }

--- a/atcoder/abc281/f/main.rs
+++ b/atcoder/abc281/f/main.rs
@@ -110,7 +110,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc281/f/main_v2.rs
+++ b/atcoder/abc281/f/main_v2.rs
@@ -127,7 +127,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc282/d/main.rs
+++ b/atcoder/abc282/d/main.rs
@@ -149,7 +149,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc282/e/main.rs
+++ b/atcoder/abc282/e/main.rs
@@ -118,7 +118,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc282/f/main.rs
+++ b/atcoder/abc282/f/main.rs
@@ -118,7 +118,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc283/d/main.rs
+++ b/atcoder/abc283/d/main.rs
@@ -95,7 +95,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc283/e/main.rs
+++ b/atcoder/abc283/e/main.rs
@@ -123,7 +123,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc283/f/main.rs
+++ b/atcoder/abc283/f/main.rs
@@ -193,7 +193,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc284/d/main.rs
+++ b/atcoder/abc284/d/main.rs
@@ -74,7 +74,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/atcoder/abc284/f/main.rs
+++ b/atcoder/abc284/f/main.rs
@@ -202,7 +202,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/cses/advanced_techniques/task2138-reachable-nodes/main.rs
+++ b/cses/advanced_techniques/task2138-reachable-nodes/main.rs
@@ -25,7 +25,7 @@ fn main() -> io::Result<()> {
             visited: &'a mut Vec<bool>,
             adj: &'a Vec<Vec<usize>>,
         }
-        fn dfs(x: usize, env: &mut Env) -> () {
+        fn dfs(x: usize, env: &mut Env) {
             for &y in env.adj[x].iter() {
                 if env.visited[y] {
                     continue;

--- a/cses/advanced_techniques/task2138-reachable-nodes/main.rs
+++ b/cses/advanced_techniques/task2138-reachable-nodes/main.rs
@@ -97,7 +97,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/cses/geometry/task2189/main.rs
+++ b/cses/geometry/task2189/main.rs
@@ -9,7 +9,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/cses/geometry/task2190-line-segment-intersection/main.rs
+++ b/cses/geometry/task2190-line-segment-intersection/main.rs
@@ -96,7 +96,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/cses/mathematics/task2182-divisor-analysis/main.rs
+++ b/cses/mathematics/task2182-divisor-analysis/main.rs
@@ -96,7 +96,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/cses/string_algorithms/task2420-palindrome-queries/main.rs
+++ b/cses/string_algorithms/task2420-palindrome-queries/main.rs
@@ -43,7 +43,7 @@ impl SegmentTree {
         }
     }
 
-    fn set(&mut self, qi: usize, qv: usize) -> () {
+    fn set(&mut self, qi: usize, qv: usize) {
         let mut k = self.n + qi;
         self.data[k] = (qv, qv, 1);
         while k > 1 {

--- a/cses/string_algorithms/task2420-palindrome-queries/main.rs
+++ b/cses/string_algorithms/task2420-palindrome-queries/main.rs
@@ -158,7 +158,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/cses/string_algorithms/task2420-palindrome-queries/main_v2.rs
+++ b/cses/string_algorithms/task2420-palindrome-queries/main_v2.rs
@@ -143,7 +143,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/cses/string_algorithms/task2420-palindrome-queries/main_v2.rs
+++ b/cses/string_algorithms/task2420-palindrome-queries/main_v2.rs
@@ -35,7 +35,7 @@ impl SegmentTree {
         }
     }
 
-    fn set(&mut self, qi: usize, qv: usize) -> () {
+    fn set(&mut self, qi: usize, qv: usize) {
         let mut k = self.n + qi;
         self.data[k] = (qv, qv, 1);
         while k > 1 {

--- a/cses/string_algorithms/task2420-palindrome-queries/main_v3.rs
+++ b/cses/string_algorithms/task2420-palindrome-queries/main_v3.rs
@@ -151,7 +151,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;

--- a/cses/string_algorithms/task2420-palindrome-queries/main_v3.rs
+++ b/cses/string_algorithms/task2420-palindrome-queries/main_v3.rs
@@ -9,7 +9,7 @@ const MODULO: usize = 7 + 1e9 as usize;
 
 static mut BASE_POWERS: Vec<usize> = Vec::new();
 
-fn precompute_base_powers() -> () {
+fn precompute_base_powers() {
     unsafe {
         let n = 2 * 100_000;
         BASE_POWERS = vec![0; n + 1];
@@ -48,7 +48,7 @@ impl SegmentTree {
         }
     }
 
-    fn set(&mut self, qi: usize, qv: usize) -> () {
+    fn set(&mut self, qi: usize, qv: usize) {
         let mut k = self.n + qi;
         self.data[k] = (qv, qv, 1);
         while k > 1 {

--- a/cses/string_algorithms/task2420-palindrome-queries/main_v4.rs
+++ b/cses/string_algorithms/task2420-palindrome-queries/main_v4.rs
@@ -9,7 +9,7 @@ const MODULO: usize = 7 + 1e9 as usize;
 
 static mut BASE_POWERS: Vec<usize> = Vec::new();
 
-fn precompute_base_powers() -> () {
+fn precompute_base_powers() {
     unsafe {
         let n = 2 * 100_000;
         BASE_POWERS = vec![0; n + 1];
@@ -48,7 +48,7 @@ impl SegmentTree {
         }
     }
 
-    fn set(&mut self, qi: usize, qv: usize) -> () {
+    fn set(&mut self, qi: usize, qv: usize) {
         let mut k = self.n + qi;
         self.data[k] = (qv, qv, 1);
         while k > 1 {

--- a/cses/string_algorithms/task2420-palindrome-queries/main_v4.rs
+++ b/cses/string_algorithms/task2420-palindrome-queries/main_v4.rs
@@ -144,7 +144,7 @@ where
     let mut line = String::new();
     io::stdin().read_line(&mut line)?;
     let mut result: Vec<F> = Vec::new();
-    for token in line.trim().split(" ") {
+    for token in line.trim().split(' ') {
         let value: F = token
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))?;


### PR DESCRIPTION
which doesn't look so convincing yet...

<details>
<summary><code>cargo clippy</code></summary>

```txt
    Checking practice v0.0.0 (/home/hiroshi/code/personal/practice)
warning: the loop variable `k` is used to index `dp`
  --> atcoder/abc263/d/main_v2.rs:16:14
   |
16 |     for k in 0..=n {
   |              ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
16 |     for (k, <item>) in dp.iter().enumerate().take(n + 1) {
   |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: binary comparison to literal `Option::None`
  --> atcoder/abc285/d/main.rs:30:25
   |
30 |                 assert!(adj[x] == None);
   |                         ^^^^^^^^^^^^^^ help: use `Option::is_none()` instead: `adj[x].is_none()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#partialeq_to_none
   = note: `#[warn(clippy::partialeq_to_none)]` on by default

warning: length comparison to zero
  --> atcoder/abc270/e/main.rs:36:8
   |
36 |     if left.len() > 0 {
   |        ^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!left.is_empty()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
   = note: `#[warn(clippy::len_zero)]` on by default

warning: `practice` (bin "atcoder-abc263-d-main-v2") generated 1 warning
warning: `practice` (bin "atcoder-abc285-d-main") generated 1 warning
warning: the loop variable `k` is used to index `intervals`
  --> atcoder/abc282/f/main.rs:18:14
   |
18 |     for k in 0..k_max {
   |              ^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
18 |     for (k, <item>) in intervals.iter_mut().enumerate().take(k_max) {
   |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: the loop variable `k` is only used to index `intervals`
  --> atcoder/abc282/f/main.rs:36:14
   |
36 |     for k in 0..k_max {
   |              ^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
help: consider using an iterator
   |
36 |     for <item> in intervals.iter().take(k_max) {
   |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: `practice` (bin "atcoder-abc270-e-main") generated 1 warning
warning: `practice` (bin "atcoder-abc282-f-main") generated 2 warnings
warning: the loop variable `i` is only used to index `dp`
  --> atcoder/abc267/d/main.rs:22:14
   |
22 |     for i in 1..=m {
   |              ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
22 |     for <item> in dp.iter_mut().take(m + 1).skip(1) {
   |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: redundant closure
  --> atcoder/abc286/c/main.rs:25:29
   |
25 |     let result = (0..n).map(|rotate| solve(rotate)).min().unwrap();
   |                             ^^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `solve`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
   = note: `#[warn(clippy::redundant_closure)]` on by default

warning: `practice` (bin "atcoder-abc267-d-main") generated 1 warning
warning: `practice` (bin "atcoder-abc286-c-main") generated 1 warning
warning: the loop variable `i` is used to index `circles`
  --> atcoder/abc259/d/main.rs:22:14
   |
22 |     for i in 0..n {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
22 |     for (i, <item>) in circles.iter().enumerate().take(n) {
   |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: length comparison to zero
  --> atcoder/abc259/d/main.rs:53:8
   |
53 |     if s_ls.len() > 0 && t_ls.len() > 0 {
   |        ^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!s_ls.is_empty()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
   = note: `#[warn(clippy::len_zero)]` on by default

warning: length comparison to zero
  --> atcoder/abc259/d/main.rs:53:26
   |
53 |     if s_ls.len() > 0 && t_ls.len() > 0 {
   |                          ^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!t_ls.is_empty()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

warning: the loop variable `i` is only used to index `ls`
  --> atcoder/abc259/e/main.rs:11:14
   |
11 |     for i in 0..n {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
11 |     for <item> in ls.iter_mut().take(n) {
   |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~

warning: use of `or_insert` followed by a call to `new`
  --> atcoder/abc259/e/main.rs:25:18
   |
25 |                 .or_insert(BTreeMap::new())
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call
   = note: `#[warn(clippy::or_fun_call)]` on by default

warning: `practice` (bin "atcoder-abc259-d-main") generated 3 warnings
warning: `practice` (bin "atcoder-abc259-e-main") generated 2 warnings
warning: the loop variable `i` is only used to index `ls`
  --> atcoder/abc279/e/main_v2.rs:17:14
   |
17 |     for i in 0..m {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
17 |     for <item> in ls.iter().take(m) {
   |         ~~~~~~    ~~~~~~~~~~~~~~~~~

warning: the loop variable `i` is only used to index `ls`
  --> atcoder/abc279/e/main_v2.rs:23:14
   |
23 |     for i in 0..m {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
help: consider using an iterator
   |
23 |     for <item> in ls.iter().take(m) {
   |         ~~~~~~    ~~~~~~~~~~~~~~~~~

warning: manual implementation of an assign operation
  --> atcoder/abc276/f/main.rs:96:17
   |
96 |                 y = y * x;
   |                 ^^^^^^^^^ help: replace it with: `y *= x`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern
   = note: `#[warn(clippy::assign_op_pattern)]` on by default

warning: suspicious use of `*` in `DivAssign` impl
   --> atcoder/abc276/f/main.rs:123:15
    |
123 |         *self *= rhs.inv();
    |               ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_op_assign_impl
    = note: `#[warn(clippy::suspicious_op_assign_impl)]` on by default

warning: `practice` (bin "atcoder-abc279-e-main-v2") generated 2 warnings
warning: `practice` (bin "atcoder-abc276-f-main") generated 2 warnings
warning: the loop variable `x` is used to index `adj`
  --> atcoder/abc278/f/main.rs:37:18
   |
37 |         for x in 0..n {
   |                  ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
37 |         for (x, <item>) in adj.iter().enumerate().take(n) {
   |             ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: the loop variable `s` is used to index `dp`
  --> atcoder/abc278/f/main.rs:52:18
   |
52 |         for s in 0..(1 << n) {
   |                  ^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
help: consider using an iterator
   |
52 |         for (s, <item>) in dp.iter().enumerate().take((1 << n)) {
   |             ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: manual implementation of an assign operation
  --> atcoder/abc280/e/main.rs:65:17
   |
65 |                 y = y * x;
   |                 ^^^^^^^^^ help: replace it with: `y *= x`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern
   = note: `#[warn(clippy::assign_op_pattern)]` on by default

warning: suspicious use of `*` in `DivAssign` impl
  --> atcoder/abc280/e/main.rs:98:15
   |
98 |         *self *= rhs.inv();
   |               ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_op_assign_impl
   = note: `#[warn(clippy::suspicious_op_assign_impl)]` on by default

warning: `practice` (bin "atcoder-abc280-e-main") generated 2 warnings
warning: `practice` (bin "atcoder-abc278-f-main") generated 2 warnings
warning: the loop variable `j` is used to index `ls`
  --> atcoder/abc283/f/main.rs:28:18
   |
28 |         for j in 0..n {
   |                  ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
28 |         for (j, <item>) in ls.iter().enumerate().take(n) {
   |             ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: the loop variable `j` is used to index `ls`
  --> atcoder/abc283/f/main.rs:44:18
   |
44 |         for j in 0..n {
   |                  ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
help: consider using an iterator
   |
44 |         for (j, <item>) in ls.iter().enumerate().take(n) {
   |             ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: the loop variable `j` is used to index `ls`
  --> atcoder/abc283/f/main.rs:59:18
   |
59 |         for j in 0..n {
   |                  ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
help: consider using an iterator
   |
59 |         for (j, <item>) in ls.iter().enumerate().take(n) {
   |             ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: the loop variable `i` is used to index `ls`
  --> atcoder/abc283/f/main.rs:74:18
   |
74 |         for i in 0..n {
   |                  ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
help: consider using an iterator
   |
74 |         for (i, <item>) in ls.iter().enumerate().take(n) {
   |             ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: length comparison to zero
  --> atcoder/abc268/d/main.rs:67:8
   |
67 |     if values.len() == 0 {
   |        ^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `values.is_empty()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
   = note: `#[warn(clippy::len_zero)]` on by default

warning: called `iter().copied().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
   --> atcoder/abc268/d/main.rs:100:52
    |
100 |         for inner in combinations(values[(i + 1)..].iter().copied().collect(), k - 1) {
    |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `.to_vec()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_cloned_collect
    = note: `#[warn(clippy::iter_cloned_collect)]` on by default

warning: the loop variable `i` is used to index `last`
   --> atcoder/abc264/e/main.rs:100:14
    |
100 |     for i in 0..e {
    |              ^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
    = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
    |
100 |     for (i, <item>) in last.iter().enumerate().take(e) {
    |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: the loop variable `i` is only used to index `ls`
  --> atcoder/abc279/e/main.rs:18:14
   |
18 |     for i in 0..m {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
18 |     for <item> in ls.iter().take(m) {
   |         ~~~~~~    ~~~~~~~~~~~~~~~~~

warning: the loop variable `i` is only used to index `ls`
  --> atcoder/abc279/e/main.rs:27:14
   |
27 |     for i in 0..m {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
help: consider using an iterator
   |
27 |     for <item> in ls.iter().take(m) {
   |         ~~~~~~    ~~~~~~~~~~~~~~~~~

warning: `practice` (bin "atcoder-abc283-f-main") generated 4 warnings
warning: `practice` (bin "atcoder-abc268-d-main") generated 2 warnings
warning: `practice` (bin "atcoder-abc279-e-main") generated 2 warnings
warning: `practice` (bin "atcoder-abc264-e-main") generated 1 warning
warning: the loop variable `i` is only used to index `ls`
 --> atcoder/abc261/e/main.rs:8:14
  |
8 |     for i in 0..n {
  |              ^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
  = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
  |
8 |     for <item> in ls.iter_mut().take(n) {
  |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~

warning: `practice` (bin "abc261-e") generated 1 warning
warning: the loop variable `x` is used to index `adj`
  --> atcoder/abc280/f/main.rs:35:14
   |
35 |     for x in 0..n {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
35 |     for (x, <item>) in adj.iter().enumerate().take(n) {
   |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: closure called just once immediately after it was declared
  --> atcoder/abc280/f/main.rs:71:9
   |
71 |         is_inf[root] = bfs();
   |         ^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_call
   = note: `#[warn(clippy::redundant_closure_call)]` on by default

warning: unneeded `return` statement
  --> atcoder/abc280/f/main.rs:69:13
   |
69 |             return false;
   |             ^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
   = note: `#[warn(clippy::needless_return)]` on by default
   = help: remove `return`

warning: the loop variable `i` is used to index `ls`
  --> atcoder/abc262/d/main_v2.rs:67:14
   |
67 |     for i in 0..n {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
67 |     for (i, <item>) in ls.iter().enumerate().take(n) {
   |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: `practice` (bin "abc262-d-v2") generated 1 warning
warning: `practice` (bin "atcoder-abc280-f-main") generated 3 warnings
warning: unneeded `return` statement
  --> atcoder/abc258/e/main.rs:28:9
   |
28 |         return result;
   |         ^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
   = note: `#[warn(clippy::needless_return)]` on by default
   = help: remove `return`

warning: redundant closure
  --> atcoder/abc258/e/main.rs:46:37
   |
46 |     let ls: Vec<usize> = (0..n).map(|i| bin_search(i)).collect();
   |                                     ^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `bin_search`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
   = note: `#[warn(clippy::redundant_closure)]` on by default

warning: length comparison to zero
  --> atcoder/abc280/d/main.rs:13:13
   |
13 |     assert!(factors.len() > 0);
   |             ^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!factors.is_empty()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
   = note: `#[warn(clippy::len_zero)]` on by default

warning: `practice` (bin "atcoder-abc258-e-main") generated 2 warnings
warning: writing `&mut Vec` instead of `&mut [_]` involves a new object where a slice will do
  --> atcoder/abc265/d/main.rs:26:35
   |
26 | fn solve(ls: &Vec<usize>, result: &mut Vec<bool>, target: usize) {
   |                                   ^^^^^^^^^^^^^^ help: change this to: `&mut [bool]`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
   = note: `#[warn(clippy::ptr_arg)]` on by default

warning: `practice` (bin "atcoder-abc280-d-main") generated 1 warning
warning: `practice` (bin "atcoder-abc265-d-main") generated 1 warning
warning: binary comparison to literal `Option::None`
  --> atcoder/abc285/d/main_v3.rs:32:25
   |
32 |                 assert!(adj[x] == None);
   |                         ^^^^^^^^^^^^^^ help: use `Option::is_none()` instead: `adj[x].is_none()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#partialeq_to_none
   = note: `#[warn(clippy::partialeq_to_none)]` on by default

warning: very complex type used. Consider factoring parts into `type` definitions
  --> atcoder/abc285/d/main_v3.rs:45:18
   |
45 |             run: RefCell<&'a mut dyn FnMut(&Dfs, usize) -> Option<()>>,
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
   = note: `#[warn(clippy::type_complexity)]` on by default

warning: redundant closure
  --> atcoder/abc285/d/main_v3.rs:77:29
   |
77 |     let result = (0..n).map(|x| dfs(x)).all(|x| x.is_some());
   |                             ^^^^^^^^^^ help: replace the closure with the function itself: `dfs`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
   = note: `#[warn(clippy::redundant_closure)]` on by default

warning: the loop variable `i` is only used to index `board`
  --> atcoder/abc278/e/main.rs:16:14
   |
16 |     for i in 0..h1 {
   |              ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
16 |     for <item> in board.iter().take(h1) {
   |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~

warning: the loop variable `i` is only used to index `board`
  --> atcoder/abc278/e/main.rs:26:18
   |
26 |         for i in k..k + h {
   |                  ^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
help: consider using an iterator
   |
26 |         for <item> in board.iter().skip(k).take(h) {
   |             ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: the loop variable `i` is only used to index `board`
  --> atcoder/abc278/e/main.rs:37:22
   |
37 |             for i in k..k + h {
   |                      ^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
help: consider using an iterator
   |
37 |             for <item> in board.iter().skip(k).take(h) {
   |                 ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: `practice` (bin "atcoder-abc278-e-main") generated 3 warnings
warning: `practice` (bin "atcoder-abc285-d-main-v3") generated 3 warnings
warning: the loop variable `v` is only used to index `parity`
  --> atcoder/abc282/d/main.rs:82:14
   |
82 |     for v in 0..n {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
82 |     for <item> in parity.iter().take(n) {
   |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~

warning: `practice` (bin "atcoder-abc282-d-main") generated 1 warning
warning: manual implementation of an assign operation
  --> atcoder/abc262/e/main.rs:20:17
   |
20 |                 y = y * x;
   |                 ^^^^^^^^^ help: replace it with: `y *= x`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern
   = note: `#[warn(clippy::assign_op_pattern)]` on by default

warning: suspicious use of `*` in `DivAssign` impl
  --> atcoder/abc262/e/main.rs:47:15
   |
47 |         *self *= rhs.inv();
   |               ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_op_assign_impl
   = note: `#[warn(clippy::suspicious_op_assign_impl)]` on by default

warning: `practice` (bin "atcoder-abc262-e-main") generated 2 warnings
warning: you seem to want to iterate on a map's values
  --> atcoder/abc273/d/main.rs:21:23
   |
21 |     for (_, holes) in &mut holes_cols {
   |                       ^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#for_kv_map
   = note: `#[warn(clippy::for_kv_map)]` on by default
help: use the corresponding method
   |
21 |     for holes in holes_cols.values_mut() {
   |         ~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~

warning: you seem to want to iterate on a map's values
  --> atcoder/abc273/d/main.rs:26:23
   |
26 |     for (_, holes) in &mut holes_rows {
   |                       ^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#for_kv_map
help: use the corresponding method
   |
26 |     for holes in holes_rows.values_mut() {
   |         ~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~

warning: redundant clone
  --> atcoder/abc274/d/main.rs:37:30
   |
37 |     let ok_y = solve(0, y, ls.clone().into_iter().skip(1).step_by(2).collect());
   |                              ^^^^^^^^ help: remove this
   |
note: this value is dropped without further use
  --> atcoder/abc274/d/main.rs:37:28
   |
37 |     let ok_y = solve(0, y, ls.clone().into_iter().skip(1).step_by(2).collect());
   |                            ^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone
   = note: `#[warn(clippy::redundant_clone)]` on by default

warning: unneeded `return` statement
  --> atcoder/abc273/d/main.rs:92:5
   |
92 |     return x0;
   |     ^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
   = note: `#[warn(clippy::needless_return)]` on by default
   = help: remove `return`

warning: the loop variable `x` is used to index `adj`
  --> atcoder/abc260/f/main_v2.rs:23:14
   |
23 |     for x in 0..s {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
23 |     for (x, <item>) in adj.iter().enumerate().take(s) {
   |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: `practice` (bin "atcoder-abc274-d-main") generated 1 warning
warning: `practice` (bin "atcoder-abc273-d-main") generated 3 warnings
warning: `practice` (bin "abc260-f-v2") generated 1 warning
warning: the loop variable `i` is used to index `ws`
  --> atcoder/abc257/c/main.rs:17:14
   |
17 |     for i in 0..n {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
17 |     for (i, <item>) in ws.iter().enumerate().take(n) {
   |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: the loop variable `i` is used to index `constraints`
  --> atcoder/abc283/e/main.rs:33:14
   |
33 |     for i in 0..h {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
33 |     for (i, <item>) in constraints.iter_mut().enumerate().take(h) {
   |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: `practice` (bin "atcoder-abc257-c-main") generated 1 warning
warning: `practice` (bin "atcoder-abc283-e-main") generated 1 warning
warning: binary comparison to literal `Option::None`
  --> atcoder/abc285/d/main_v2.rs:32:25
   |
32 |                 assert!(adj[x] == None);
   |                         ^^^^^^^^^^^^^^ help: use `Option::is_none()` instead: `adj[x].is_none()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#partialeq_to_none
   = note: `#[warn(clippy::partialeq_to_none)]` on by default

warning: very complex type used. Consider factoring parts into `type` definitions
  --> atcoder/abc285/d/main_v2.rs:43:14
   |
43 |         run: RefCell<&'a mut dyn FnMut(&Dfs, usize) -> Option<()>>,
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
   = note: `#[warn(clippy::type_complexity)]` on by default

warning: `practice` (bin "atcoder-abc285-d-main-v2") generated 2 warnings
warning: casting integer literal to `f64` is unnecessary
  --> atcoder/abc274/e/main.rs:24:9
   |
24 |         (2 as f64).powf(num_acc as f64)
   |         ^^^^^^^^^^ help: try: `2_f64`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
   = note: `#[warn(clippy::unnecessary_cast)]` on by default

warning: the loop variable `s` is used to index `dp`
  --> atcoder/abc274/e/main.rs:55:14
   |
55 |     for s in 0..(1 << k) {
   |              ^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
55 |     for (s, <item>) in dp.iter().enumerate().take((1 << k)) {
   |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: binary comparison to literal `Option::None`
  --> atcoder/abc285/d/main_v4.rs:32:25
   |
32 |                 assert!(adj[x] == None);
   |                         ^^^^^^^^^^^^^^ help: use `Option::is_none()` instead: `adj[x].is_none()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#partialeq_to_none
   = note: `#[warn(clippy::partialeq_to_none)]` on by default

warning: the loop variable `p` is used to index `positions`
  --> atcoder/abc274/e/main.rs:59:18
   |
59 |         for p in 0..k {
   |                  ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
help: consider using an iterator
   |
59 |         for (p, <item>) in positions.iter().enumerate().take(k) {
   |             ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: redundant closure
  --> atcoder/abc285/d/main_v4.rs:60:29
   |
60 |     let result = (0..n).map(|x| dfs(x)).all(|x| x.is_some());
   |                             ^^^^^^^^^^ help: replace the closure with the function itself: `dfs`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
   = note: `#[warn(clippy::redundant_closure)]` on by default

warning: unneeded `return` statement
  --> atcoder/abc274/e/main.rs:73:5
   |
73 |     return (dx * dx + dy * dy).sqrt();
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
   = note: `#[warn(clippy::needless_return)]` on by default
   = help: remove `return`

warning: the loop variable `i` is only used to index `dists`
  --> atcoder/abc272/d/main.rs:37:14
   |
37 |     for i in 0..n {
   |              ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
37 |     for <item> in dists.iter().take(n) {
   |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~

warning: `practice` (bin "atcoder-abc285-d-main-v4") generated 2 warnings
warning: `practice` (bin "atcoder-abc274-e-main") generated 4 warnings
warning: `practice` (bin "atcoder-abc272-d-main") generated 1 warning
warning: manual implementation of an assign operation
   --> atcoder/abc275/e/main.rs:102:17
    |
102 |                 y = y * x;
    |                 ^^^^^^^^^ help: replace it with: `y *= x`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern
    = note: `#[warn(clippy::assign_op_pattern)]` on by default

warning: suspicious use of `*` in `DivAssign` impl
   --> atcoder/abc275/e/main.rs:129:15
    |
129 |         *self *= rhs.inv();
    |               ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_op_assign_impl
    = note: `#[warn(clippy::suspicious_op_assign_impl)]` on by default

warning: `practice` (bin "atcoder-abc275-e-main") generated 2 warnings
warning: manual implementation of an assign operation
   --> atcoder/abc284/f/main.rs:117:17
    |
117 |                 y = y * x;
    |                 ^^^^^^^^^ help: replace it with: `y *= x`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern
    = note: `#[warn(clippy::assign_op_pattern)]` on by default

warning: suspicious use of `*` in `DivAssign` impl
   --> atcoder/abc284/f/main.rs:150:15
    |
150 |         *self *= rhs.inv();
    |               ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_op_assign_impl
    = note: `#[warn(clippy::suspicious_op_assign_impl)]` on by default

warning: `practice` (bin "atcoder-abc284-f-main") generated 2 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 1.53s
```

</details>